### PR TITLE
Fix merge request link

### DIFF
--- a/src/Route/GitLabRoutes.php
+++ b/src/Route/GitLabRoutes.php
@@ -43,7 +43,7 @@ class GitLabRoutes extends RouteMatcher
             'blob' => "^${nwo}/blob/(?P<ref>[^/]+)/(?P<file_path>.+?)(?:#${line}(?:-${line2})?)?$",
             'note' => "^${nwo}/(?:issues|merge_requests)/(?P<number>\d+)#note_(?P<id>\d+)",
             'issue' => "^${nwo}/issues/(?P<number>\d+)$",
-            'merge_request' => "^${nwo}/merge_requests/(?P<number>\d+)$",
+            'merge_request' => "^${nwo}/merge_requests/(?P<number>\d+)(/(commits|pipelines|diffs))?$",
             'account' => "^${base}${namespace}$",
             'project' => "^${nwo}$",
         ];

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -80,6 +80,24 @@ class RouteTest extends TestCase
                 'repo' => 'gitlab-ce',
                 'number' => '6721',
             ]],
+            ['merge_request', 'https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/6721/commits', [
+                'namespace' => 'gitlab-org/',
+                'project_path' => 'gitlab-org/gitlab-ce',
+                'repo' => 'gitlab-ce',
+                'number' => '6721',
+            ]],
+            ['merge_request', 'https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/6721/pipelines', [
+                'namespace' => 'gitlab-org/',
+                'project_path' => 'gitlab-org/gitlab-ce',
+                'repo' => 'gitlab-ce',
+                'number' => '6721',
+            ]],
+            ['merge_request', 'https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/6721/diffs', [
+                'namespace' => 'gitlab-org/',
+                'project_path' => 'gitlab-org/gitlab-ce',
+                'repo' => 'gitlab-ce',
+                'number' => '6721',
+            ]],
             ['note', 'https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/6721#note_16627667', [
                 'namespace' => 'gitlab-org/',
                 'project_path' => 'gitlab-org/gitlab-ce',


### PR DESCRIPTION
# What does this MR do?

This MR is updating GitLab merge request links matching, as GitLab can also provide this links with commit, pipelines or diff tab opened.