### PR TITLE
Allow null description from API, fixes #6

### DIFF
--- a/src/Traits/SanitizeTextTrait.php
+++ b/src/Traits/SanitizeTextTrait.php
@@ -4,7 +4,7 @@ namespace GitlabSlackUnfurl\Traits;
 
 trait SanitizeTextTrait
 {
-    protected function sanitizeText(string $text): string
+    protected function sanitizeText(?string $text): string
     {
         $text = str_replace("\r\n", "\n", $text);
         $text = trim($text);

--- a/tests/Resources/DataProvider/issues.yml
+++ b/tests/Resources/DataProvider/issues.yml
@@ -20,5 +20,22 @@
         short: true
   -
     - GitLab/issue-12733.json
+-
+  - https://gitlab.com/glensc/playground/issues/1
+  - namespace: glensc/
+    project_path: glensc/playground
+    repo: playground
+    number: 1
+  - title: '<https://gitlab.com/glensc/playground/issues/1|#1>: Issue with no description'
+    text: ''
+    color: '#E24329'
+    ts: 1540200871
+    footer: 'Created by <https://gitlab.com/glensc|Elan Ruusamäe>'
+    fields:
+      - title: Assignee
+        value: '<https://gitlab.com/glensc|Elan Ruusamäe>'
+        short: true
+  -
+    - GitLab/issue-1.json
 
 # vim:ts=2:sw=2:et

--- a/tests/Resources/GitLab/issue-1.json
+++ b/tests/Resources/GitLab/issue-1.json
@@ -1,0 +1,54 @@
+{
+  "id": 15133478,
+  "iid": 1,
+  "project_id": 8986378,
+  "title": "Issue with no description",
+  "description": "",
+  "state": "opened",
+  "created_at": "2018-10-22T09:34:31.935Z",
+  "updated_at": "2018-10-22T09:34:31.935Z",
+  "closed_at": null,
+  "closed_by": null,
+  "labels": [],
+  "milestone": null,
+  "assignees": [
+    {
+      "id": 163557,
+      "name": "Elan Ruusamäe",
+      "username": "glensc",
+      "state": "active",
+      "avatar_url": "https://secure.gravatar.com/avatar/effff0989c8041ef98aaf916c7092d6d?s=80\u0026d=identicon",
+      "web_url": "https://gitlab.com/glensc"
+    }
+  ],
+  "author": {
+    "id": 163557,
+    "name": "Elan Ruusamäe",
+    "username": "glensc",
+    "state": "active",
+    "avatar_url": "https://secure.gravatar.com/avatar/effff0989c8041ef98aaf916c7092d6d?s=80\u0026d=identicon",
+    "web_url": "https://gitlab.com/glensc"
+  },
+  "assignee": {
+    "id": 163557,
+    "name": "Elan Ruusamäe",
+    "username": "glensc",
+    "state": "active",
+    "avatar_url": "https://secure.gravatar.com/avatar/effff0989c8041ef98aaf916c7092d6d?s=80\u0026d=identicon",
+    "web_url": "https://gitlab.com/glensc"
+  },
+  "user_notes_count": 1,
+  "upvotes": 0,
+  "downvotes": 0,
+  "due_date": null,
+  "confidential": false,
+  "discussion_locked": null,
+  "web_url": "https://gitlab.com/glensc/playground/issues/1",
+  "time_stats": {
+    "time_estimate": 0,
+    "total_time_spent": 0,
+    "human_time_estimate": null,
+    "human_total_time_spent": null
+  },
+  "weight": null
+}

--- a/tests/UnfurlTest.php
+++ b/tests/UnfurlTest.php
@@ -22,7 +22,7 @@ class UnfurlTest extends TestCase
     {
         $router = new GitLabRoutes($this->domain);
         $match = $router->match($url)[1];
-        $this->assertEquals($match, $parts);
+        $this->assertEquals($parts, $match);
 
         /** @var Route\Issue $unfurler */
         $unfurler = $this->getRouteHandler(Route\Issue::class, $responses);
@@ -42,7 +42,7 @@ class UnfurlTest extends TestCase
     {
         $router = new GitLabRoutes($this->domain);
         $match = $router->match($url)[1];
-        $this->assertEquals($match, $parts);
+        $this->assertEquals($parts, $match);
 
         /** @var Route\MergeRequest $unfurler */
         $unfurler = $this->getRouteHandler(Route\MergeRequest::class, $responses);
@@ -62,7 +62,7 @@ class UnfurlTest extends TestCase
     {
         $router = new GitLabRoutes($this->domain);
         $match = $router->match($url)[1];
-        $this->assertEquals($match, $parts);
+        $this->assertEquals($parts, $match);
 
         /** @var Route\Note $unfurler */
         $unfurler = $this->getRouteHandler(Route\Note::class, $responses);


### PR DESCRIPTION
Altho could not reproduce this with actual api query. i've mocked `null` result and committed the fix.

cc @joelsdc