### PR TITLE
Remove html comments from markdown input

### DIFF
--- a/src/Traits/SanitizeTextTrait.php
+++ b/src/Traits/SanitizeTextTrait.php
@@ -7,6 +7,8 @@ trait SanitizeTextTrait
     protected function sanitizeText(?string $text): string
     {
         $text = str_replace("\r\n", "\n", $text);
+        // remove html comments
+        $text = preg_replace("/<!--.*?-->/s", "", $text);
         $text = trim($text);
 
         return $text;

--- a/tests/Resources/text.expected.md
+++ b/tests/Resources/text.expected.md
@@ -1,0 +1,2 @@
+# General info
+* Service name: API

--- a/tests/Resources/text.input.md
+++ b/tests/Resources/text.input.md
@@ -1,0 +1,13 @@
+<!--
+Title template:
+Offboard {SERVICE_NAME} in {COUNTRIE(S)}
+-->
+<!--
+#############################################################
+Section for issue creator to fill
+#############################################################
+-->
+# General info
+* Service name: API
+
+<!-- Remove irrelevant environments (countries + test/production) and steps  -->

--- a/tests/SanitizeTextTest.php
+++ b/tests/SanitizeTextTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GitlabSlackUnfurl\Test;
+
+use GitlabSlackUnfurl\Traits\SanitizeTextTrait;
+
+class SanitizeTextTest extends TestCase
+{
+    /**
+     * @var SanitizeTextTrait
+     */
+    private $sanitize;
+
+    public function setUp(): void
+    {
+        $this->sanitize = new class {
+            use SanitizeTextTrait;
+
+            public function sanitize(string $input): string
+            {
+                return $this->sanitizeText($input);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider sanitizeData
+     */
+    public function testStripHtml(string $input, string $expected)
+    {
+        $result = $this->sanitize->sanitize($input);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function sanitizeData()
+    {
+        yield [
+            $this->readFile('text.input.md'),
+            $this->readFile('text.expected.md'),
+        ];
+    }
+
+    private function readFile($name)
+    {
+        $fileName = __DIR__ . '/Resources/' . $name;
+        $contents = file_get_contents($fileName);
+
+        return trim($contents);
+    }
+}


### PR DESCRIPTION
It's quite common to embed some guides to markdown issue templates. those should not be unfurled to slack